### PR TITLE
Logic fix

### DIFF
--- a/locations.csv
+++ b/locations.csv
@@ -13,7 +13,7 @@ Quest: Black Knights' Fortress,Quest,"Dwarven Mines, Falador, Monastery, Ice Mou
 Quest: Witch's Potion,Quest,"Rimmington, Port Sarim",,,,QuestTask,,,
 Quest: The Knight's Sword,Quest,"Falador, Varrock Palace, Mudskipper Point, South of Varrock, Windmill, Pie Dish, Port Sarim","Cooking 10, Mining 10",,,QuestTask,,,
 Quest: Goblin Diplomacy,Quest,"Goblin Village, Draynor Village, Falador, South of Varrock, Onion",,,,QuestTask,,,
-Quest: Pirate's Treasure,Quest,"Port Sarim, Karamja, Falador",,,,QuestTask,,,
+Quest: Pirate's Treasure,Quest,"Port Sarim, Karamja, Mudskipper Point, Falador",,,,QuestTask,,,
 Quest: Rune Mysteries,Quest,"Lumbridge, Wizard Tower, Central Varrock",,,,QuestTask,,,
 Quest: Misthalin Mystery,Quest,Lumbridge Swamp,,,,QuestTask,,,
 Quest: The Corsair Curse,Quest,"Rimmington, Falador Farms, Corsair Cove",,,,QuestTask,,,


### PR DESCRIPTION
Added Karamja Docks (Mudskipper Point) as a required area to complete Quest: Pirate's Treasure due to starting on the ship in that chunk when traveling from Port Sarim.